### PR TITLE
[#1] Use placeholder instead of value to prevent 'http://' only

### DIFF
--- a/views/home.erb
+++ b/views/home.erb
@@ -2,7 +2,7 @@
   <h1>MetaInspector <%= MetaInspector::VERSION %> demo</h1>
   <h2>Just a little demo of the MetaInspector scraper gem</h2>
   <form class="form-search" method="GET" action="/scrape">
-    <input type="url" name="url" class="input-medium search-query" required value="http://">
+    <input type="url" name="url" class="input-medium search-query" required placeholder="http://">
     <button type="submit" class="btn">Scrape</button>
   </form>
 </div>


### PR DESCRIPTION
@jaimeiniesta the problem happens when the `params[:url]` has only the `http://`, it raises the following error:

```
Addressable::URI::InvalidURIError - Absolute URI missing hierarchical segment: 'http://':
```

I believe the best way to handle, would be just change the value for place holder.
